### PR TITLE
fix double wait in sendMessage

### DIFF
--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -1497,7 +1497,6 @@ class WhatsProt
     {
         $bodyNode = new ProtocolNode("body", null, null, $txt);
         $id = $this->sendMessageNode($to, $bodyNode, $id);
-        $this->waitForServer($id);
 
         if ($this->messageStore !== null) {
             $this->messageStore->saveMessage($this->phoneNumber, $to, $txt, $id, time());


### PR DESCRIPTION
remove double and wrong `$this->waitForServer($id)` call in `sendMessage` since the called `sendMessageNode` does it already. 

Without this fix, the second waitForServer either times out or reacts to the onClientReceived notification which can cause some race conditions.