### PR TITLE
Fix ProtocolNode syntax in sendGroupsChangeParticipants

### DIFF
--- a/src/protocol.class.php
+++ b/src/protocol.class.php
@@ -78,7 +78,7 @@ class ProtocolNode
         return $this->children;
     }
 
-    public function __construct($tag, $attributeHash, $children, $data)
+    public function __construct($tag, $attributeHash, array $children, $data)
     {
         $this->tag           = $tag;
         $this->attributeHash = $attributeHash;

--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -3812,7 +3812,7 @@ class WhatsProt
         $participants = new ProtocolNode("participant", array("jid" => $this->getJID($participant)), null, "");
 
         $childHash = array();
-        $child = new ProtocolNode($tag, $childHash, $participants, "");
+        $child = new ProtocolNode($tag, $childHash, array($participants), "");
 
         $node = new ProtocolNode("iq",
             array(


### PR DESCRIPTION
Fixes
> PHP Fatal error:  Call to a member function nodeString() on a non-object in [..]/whatsapp/chat-api/src/protocol.class.php on line 127

Got the error when trying to use sendPromoteParticipants