### PR TITLE
group media messages ack sent correctly now; fixes #1092

### DIFF
--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -2801,7 +2801,8 @@ class WhatsProt
                 }
 
                 if ($autoReceipt) {
-                    $this->sendReceipt($node, $type);
+                    $author = $node->getAttribute("participant");
+                    $this->sendReceipt($node, $type, $author);
                 }
             }
             if ($node->getChild('received') != null) {


### PR DESCRIPTION
Earlier group media messages did not have the required "participant" attribute in the acks