### PR TITLE
fix empty() usage for php < 5.5

### DIFF
--- a/src/Login.php
+++ b/src/Login.php
@@ -60,7 +60,8 @@ class Login
       if (extension_loaded('curve25519') || extension_loaded('protobuf')) {
         if (file_exists(__DIR__ . DIRECTORY_SEPARATOR . Constants::DATA_FOLDER . DIRECTORY_SEPARATOR . "axolotl-" . $this->phoneNumber . ".db"))
         {
-          if (empty($this->parent->getAxolotlStore()->loadPreKeys()))
+          $result = $this->parent->getAxolotlStore()->loadPreKeys();
+          if (empty($result))
           {
             $this->parent->sendSetPreKeys();
             $this->parent->logFile('info', 'Sending prekeys to WA server');


### PR DESCRIPTION
Fix for php error `Can't use method return value in write context`